### PR TITLE
detect submodules as repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The "installation":
 
 * Add the `_version.py` to the root of your library (next to the `__init__.py`).
 * Set the project name and `__version__` string.
-* In your `__init__.py`, use `from _version import __version__, version_info`.
+* In your `__init__.py`, use `.from _version import __version__, version_info`.
 * In `pyproject.toml` use `dynamic = ["version"]`.
 * The Flit build tool will now detect your project version. Other tools may
   need an extra line, e.g. `[tool.hatch.version]` `path = "lib_name/_version.py"`.

--- a/_version.py
+++ b/_version.py
@@ -1,5 +1,5 @@
 """
-_version.py v1.2
+_version.py v1.3
 
 Simple version string management, using a hard-coded version string
 for simplicity and compatibility, while adding git info at runtime.
@@ -31,7 +31,7 @@ logger = logging.getLogger(project_name)
 
 # Get whether this is a repo. If so, repo_dir is the path, otherwise None.
 repo_dir = Path(__file__).parents[1]
-repo_dir = repo_dir if repo_dir.joinpath(".git").is_dir() else None
+repo_dir = repo_dir if repo_dir.joinpath(".git").exists() else None
 
 
 def get_version():


### PR DESCRIPTION
Hey, 

I pulled my forks and noticed this didn't work as expected. Turns out I have some projects inside a git submodule. In this case there is no `.git` directory but instead a `.git` file on the parent directory. 
I looked through the docs and sounds like `.exists()` will check for both - this might not be foolproof but it seems to work for me (on Windows). I tested submodule and direct clone with this change.

Also noticed that the import needs to be relative (and is on pygfx, wpgu and rendercanvas), so added a commit for that.



