### PR TITLE
Use Ruff default line length

### DIFF
--- a/_version.py
+++ b/_version.py
@@ -90,9 +90,7 @@ def get_version_info_from_git() -> str:
         "--first-parent",
     ]
     try:
-        p = subprocess.run(
-            command, check=False, cwd=repo_dir, capture_output=True
-        )
+        p = subprocess.run(command, check=False, cwd=repo_dir, capture_output=True)
     except Exception as e:
         warning(f"Could not get {project_name} version: {e}")
         p = None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,3 @@
-[tool.ruff]
-line-length = 80
-
 [tool.ruff.lint]
 # Run all the rules, we turn some rules off in the file itself.
 select = ["ALL"]


### PR DESCRIPTION
Using the default (recommended) line length enhances the chance that the file can be copied without change. Not a big deal with autoformatters, but still nice.

Not bumping the version number; the logic is the same, and this change comes quickly after the latest bump.